### PR TITLE
style: auto-fix formatting issues with Rustfmt, make CI pass

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,2 @@
 hard_tabs = true
 tab_spaces = 4
-imports_layout = "HorizontalVertical"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,14 +80,15 @@ impl StringDiffAlgorithm for HammingDistance {
 			let mut opp_vec: Vec<StringDiffOp> = Vec::new();
 			for i in 0..s1.len() {
 				if s1.chars().nth(i).unwrap() != s2.chars().nth(i).unwrap() {
-					let new_opp = StringDiffOp::new_substitute
-						(s1.chars().nth(i).unwrap(),
+					let new_opp = StringDiffOp::new_substitute(
+						s1.chars().nth(i).unwrap(),
 						s2.chars().nth(i).unwrap(),
-						i);
+						i,
+					);
 					opp_vec.push(new_opp)
 				}
 			}
-		    opp_vec
+			opp_vec
 		}
 	}
 
@@ -157,7 +158,6 @@ impl LevenshteinDistance {
 		let mut prev_char: char = ' ';
 
 		loop {
-
 			if top_str_len == 0 && left_str_len == 0 {
 				break;
 			}


### PR DESCRIPTION
Disables configuring `import_layouts`, this is an unstable feature and only available on the nightly channel, but this library is specifically for the stable version of Rust.