### PR TITLE
Fix: Getting rid of dup code

### DIFF
--- a/src/hamming.rs
+++ b/src/hamming.rs
@@ -1,6 +1,7 @@
 use crate::{StringDiffAlgorithm, StringDiffOp};
 
 pub struct HammingDistance {}
+impl HammingDistance{}
 impl StringDiffAlgorithm for HammingDistance {
 	fn diff<'a>(&self, s1: &'a str, s2: &'a str) -> Vec<StringDiffOp> {
 		if s1.len() != s2.len() {
@@ -22,17 +23,7 @@ impl StringDiffAlgorithm for HammingDistance {
 	}
 
 	fn distance<'a>(&self, s1: &'a str, s2: &'a str) -> usize {
-		if s1.len() != s2.len() {
-			panic!("Strings must be same length");
-		} else {
-			let mut edit_distance: usize = 0;
-			for i in 0..s1.len() {
-				if s1.chars().nth(i).unwrap() != s2.chars().nth(i).unwrap() {
-					edit_distance += 1;
-				}
-			}
-			edit_distance
-		}
+        self.diff(s1, s2).len()
 	}
 }
 

--- a/src/hamming.rs
+++ b/src/hamming.rs
@@ -1,7 +1,6 @@
 use crate::{StringDiffAlgorithm, StringDiffOp};
 
 pub struct HammingDistance {}
-impl HammingDistance{}
 impl StringDiffAlgorithm for HammingDistance {
 	fn diff<'a>(&self, s1: &'a str, s2: &'a str) -> Vec<StringDiffOp> {
 		if s1.len() != s2.len() {
@@ -23,7 +22,7 @@ impl StringDiffAlgorithm for HammingDistance {
 	}
 
 	fn distance<'a>(&self, s1: &'a str, s2: &'a str) -> usize {
-        self.diff(s1, s2).len()
+		self.diff(s1, s2).len()
 	}
 }
 

--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -114,7 +114,7 @@ impl LevenshteinDistance {
 
 		diff_ops
 	}
-    pub(crate) fn get_operation_matrix(s1: &str, s2: &str) -> Vec<Vec<char>> {
+	pub(crate) fn get_operation_matrix(s1: &str, s2: &str) -> Vec<Vec<char>> {
 		let first_string_len: usize = s1.len();
 		let second_string_len: usize = s2.len();
 
@@ -152,17 +152,16 @@ impl LevenshteinDistance {
 				); //substitution
 			}
 		}
-        dir_vector
-    }
-
+		dir_vector
+	}
 }
 impl StringDiffAlgorithm for LevenshteinDistance {
 	fn diff<'a>(&self, s1: &'a str, s2: &'a str) -> Vec<StringDiffOp> {
-        let dir_matrix = LevenshteinDistance::get_operation_matrix(s1, s2);
+		let dir_matrix = LevenshteinDistance::get_operation_matrix(s1, s2);
 		LevenshteinDistance::get_operations(&dir_matrix, s2, s1)
 	}
 	fn distance<'a>(&self, s1: &'a str, s2: &'a str) -> usize {
-        let dir_matrix = LevenshteinDistance::get_operation_matrix(s1, s2);
+		let dir_matrix = LevenshteinDistance::get_operation_matrix(s1, s2);
 		LevenshteinDistance::get_operations(&dir_matrix, s2, s1).len()
 	}
 }

--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -114,9 +114,7 @@ impl LevenshteinDistance {
 
 		diff_ops
 	}
-}
-impl StringDiffAlgorithm for LevenshteinDistance {
-	fn diff<'a>(&self, s1: &'a str, s2: &'a str) -> Vec<StringDiffOp> {
+    pub(crate) fn get_operation_matrix(s1: &str, s2: &str) -> Vec<Vec<char>> {
 		let first_string_len: usize = s1.len();
 		let second_string_len: usize = s2.len();
 
@@ -154,39 +152,18 @@ impl StringDiffAlgorithm for LevenshteinDistance {
 				); //substitution
 			}
 		}
+        dir_vector
+    }
 
-		LevenshteinDistance::get_operations(&dir_vector, s2, s1)
+}
+impl StringDiffAlgorithm for LevenshteinDistance {
+	fn diff<'a>(&self, s1: &'a str, s2: &'a str) -> Vec<StringDiffOp> {
+        let dir_matrix = LevenshteinDistance::get_operation_matrix(s1, s2);
+		LevenshteinDistance::get_operations(&dir_matrix, s2, s1)
 	}
 	fn distance<'a>(&self, s1: &'a str, s2: &'a str) -> usize {
-		let first_string_len: usize = s1.len();
-		let second_string_len: usize = s2.len();
-
-		let mut dist_vector = vec![vec![0usize; first_string_len + 1]; second_string_len + 1];
-
-		for i in 0..first_string_len + 1 {
-			dist_vector[0][i] = i;
-		}
-
-		for i in 0..second_string_len + 1 {
-			dist_vector[i][0] = i;
-		}
-
-		let mut sub_cost: usize = 0;
-		for i in 1..second_string_len + 1 {
-			for j in 1..first_string_len + 1 {
-				if s1.chars().nth(j - 1).unwrap() == s2.chars().nth(i - 1).unwrap() {
-					sub_cost = 0;
-				} else {
-					sub_cost = 1;
-				}
-				dist_vector[i][j] = LevenshteinDistance::min_dist(
-					dist_vector[i - 1][j] + 1,
-					dist_vector[i][j - 1] + 1,
-					dist_vector[i - 1][j - 1] + sub_cost,
-				);
-			}
-		}
-		dist_vector[second_string_len][first_string_len]
+        let dir_matrix = LevenshteinDistance::get_operation_matrix(s1, s2);
+		LevenshteinDistance::get_operations(&dir_matrix, s2, s1).len()
 	}
 }
 


### PR DESCRIPTION
Fixes #9

I had a different approach let me know what you think. For levenshtein distance I converted the matrix computations functions as a helper function. Then diff and distance call this helper function. This way we don't have any dupe code. Hamming works similar. 

On hamming.rs line 4 I added that unnecessary line. Ill fix it after I get feedback from the code.