### PR TITLE
perf: use `std::iter::zip()` to iterate over both strings in hamming algorithm

### DIFF
--- a/crates/differ/src/hamming.rs
+++ b/crates/differ/src/hamming.rs
@@ -1,24 +1,22 @@
 use crate::{StringDiffAlgorithm, StringDiffOp};
+use std::iter::zip;
 
 pub struct HammingDistance {}
 impl StringDiffAlgorithm for HammingDistance {
 	fn diff<'a>(&self, s1: &'a str, s2: &'a str) -> Vec<StringDiffOp> {
 		if s1.len() != s2.len() {
 			panic!("Strings must be same length");
-		} else {
-			let mut opp_vec: Vec<StringDiffOp> = Vec::new();
-			for i in 0..s1.len() {
-				if s1.chars().nth(i).unwrap() != s2.chars().nth(i).unwrap() {
-					let new_opp = StringDiffOp::new_substitute(
-						s1.chars().nth(i).unwrap(),
-						s2.chars().nth(i).unwrap(),
-						i,
-					);
-					opp_vec.push(new_opp)
-				}
-			}
-			opp_vec
 		}
+
+		let mut opp_vec: Vec<StringDiffOp> = Vec::new();
+		let iter = zip(s1.chars(), s2.chars());
+
+		for (i, (char1, char2)) in iter.enumerate() {
+			if char1 != char2 {
+				opp_vec.push(StringDiffOp::new_substitute(char1, char2, i));
+			}
+		}
+		opp_vec
 	}
 
 	fn distance<'a>(&self, s1: &'a str, s2: &'a str) -> usize {


### PR DESCRIPTION
 - Calling the `nth()` takes O(n) (linear) time complexity. This replaces the current loop with `std::iter::zip()`, which creates an iterator that iterates over two iterators simultaneously. The `enumerate()` method (on the `Iterator` trait) allows accessing the index *and* item at the same time, so we can use it here.
 - Get rid of unnecessary `unwrap()` calls
 - Inline the `new_opp` variable, since it's only used to push into the vector
 - (style) take out of else branch to make code more readable