### PR TITLE
ci: improve overall CI workflows

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -3,6 +3,7 @@ name: commit-lint
 on:
   pull_request:
   push:
+    - main
 
 jobs:
   commit-lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,3 +13,5 @@ jobs:
         with:
           release-type: rust
           package-name: nlp-rs-rust-template
+          plugins:
+            - 'cargo-workspace'


### PR DESCRIPTION
 - don't make `commit-lint` workflow run twice on pull requests
 - make release-please understand Cargo workspaces (follow up to 440dffa)